### PR TITLE
add GH actions

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -1,0 +1,40 @@
+name: Publish Docker Image
+# https://www.docker.com/blog/first-docker-github-action-is-here
+# https://github.com/docker/build-push-action
+on:  # Trigger the workflow on push or pull request, but only for the master branch
+  push: {}
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-push:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python_version: [ 2.7, 3.6, 3.7, 3.8, 3.9 ]
+        opencv_version: [ 4.5.1 ]
+        device: [ "gpu" ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      # https://github.com/docker/setup-buildx-action
+      # Set up Docker Buildx - to use cache-from and cache-to argument of buildx command
+      - uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Publish to Docker Hub
+        # publish master
+        uses: docker/build-push-action@v2
+        # https://github.com/docker/build-push-action#cache-to-registry
+        with:
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python_version }}
+            OPENCV_VERSION=${{ matrix.opencv_version }}
+          file: ${{ matrix.device }}/Dockerfile
+          push: ${{ github.ref == 'refs/heads/master' }}
+          tags: borda/docker_python-opencv-ffmpeg:${{ matrix.device }}-py${{ matrix.python_version }}-cv${{ matrix.opencv_version }}
+        timeout-minutes: 240

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Repository for clean Dockerfile containing [FFmpeg](https://www.ffmpeg.org/), [O
 
 ## Build
 
+[![Publish Docker Image](https://github.com/Borda/docker_python-opencv-ffmpeg/workflows/Publish%20Docker%20Image/badge.svg?branch=master&event=push)](https://github.com/Borda/docker_python-opencv-ffmpeg/actions?query=workflow%3A%22Publish+Docker+Image%22)
 [![CircleCI](https://circleci.com/gh/Borda/docker_python-opencv-ffmpeg/tree/master.svg?style=svg)](https://circleci.com/gh/Borda/docker_python-opencv-ffmpeg/tree/master)
 [![Docker Build Status](https://img.shields.io/docker/build/borda/docker_python-opencv-ffmpeg)](https://hub.docker.com/r/borda/docker_python-opencv-ffmpeg)
 [![DockerHub Pulls](https://img.shields.io/docker/pulls/borda/docker_python-opencv-ffmpeg.svg)](https://hub.docker.com/r/borda/docker_python-opencv-ffmpeg)

--- a/circle.yml
+++ b/circle.yml
@@ -34,14 +34,15 @@ jobs:
     parameters:
       python:
         type: string
-      device:
-        type: string
+      # device:
+      #   type: string
     machine: true
     environment:
       - IMAGE: "ubuntu-opencv"
       - PYTHON: << parameters.python >>
       - OPENCV: "4.5.1"
-      - DEVICE: << parameters.device >>
+      # - DEVICE: << parameters.device >>
+      - DEVICE: "cpu"
     steps:
       - checkout
       - *build_image
@@ -55,4 +56,4 @@ workflows:
           matrix:
             parameters:
               python: ["2.7", "3.6", "3.7", "3.8", "3.9"]
-              device: ["cpu", "gpu"]
+              # device: ["cpu", "gpu"]


### PR DESCRIPTION
building on CircleCI takes too many resources of the free limit...
some move the long GPU builds to GH actions and keep CircleCI just as a backup plan 🐰 