### PR TITLE
Allow override of CUDA_ARCH_BIN

### DIFF
--- a/gpu/Dockerfile
+++ b/gpu/Dockerfile
@@ -13,6 +13,7 @@ LABEL maintainer="https://github.com/Borda"
 
 ARG PYTHON_VERSION=3.9
 ARG OPENCV_VERSION=4.5.5
+ARG CUDA_ARCH_BIN="5.3 6.1 7.0 7.5"
 
 # Needed for string substitution
 SHELL ["/bin/bash", "-c"]
@@ -148,7 +149,7 @@ RUN \
       -D CMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs \
       # https://kezunlin.me/post/6580691f
       # https://stackoverflow.com/questions/28010399/build-opencv-with-cuda-support
-      -D CUDA_ARCH_BIN="5.3 6.1 7.0 7.5" \
+      -D CUDA_ARCH_BIN=${CUDA_ARCH_BIN} \
       -D CUDA_ARCH_PTX="" \
       -D WITH_CUBLAS=ON \
       -D WITH_NVCUVID=ON \


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Use new arg for CUDA_ARCH_BIN to allow user to override when building; this is a modification I have personally found useful when building for use on GPUs with other CUDA compute capabilities (see https://developer.nvidia.com/cuda-gpus).

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
